### PR TITLE
Fix minor docs usage typo

### DIFF
--- a/docs_src/content/docs/usage.md
+++ b/docs_src/content/docs/usage.md
@@ -5,13 +5,13 @@
 Map harbor project to several namespaces. This will create a robot account in `my-project` **harbor project** and sync the credentials into `team-a` and `team-b`'s namespace as secret `central-project-token`.
 
 ```yml
-kind: HaborSync
+kind: HarborSync
 metadata:
   name: my-project
 spec:
   type: Regex
   name: "my-project" # <--- specify harbor project
-  robotAccountSuffix: "k8s-sync-robot" # <--- should be unique per kind: HaborSync
+  robotAccountSuffix: "k8s-sync-robot" # <--- should be unique per kind: HarborSync
   mapping:
   - type: Translate
     namespace: "team-a" # <--- target namespace
@@ -28,7 +28,7 @@ spec:
 You can specify regular expressions to map a **large number** of projects to namespaces. This maps harbor teams with the prefix `team-`. E.g. Harbor project `team-frontend` maps to k8s namespace `team-frontend`. The secret's name will always be `my-pull-token`. Non-existent k8s namespaces will be ignored.
 
 ```yaml
-kind: HaborSync
+kind: HarborSync
 metadata:
   name: team-projects
 spec:
@@ -51,7 +51,7 @@ Use a `type: Match` on a mapping to say: hey, find namespaces using this **regul
 
 
 ```yaml
-kind: HaborSync
+kind: HarborSync
 metadata:
   name: platform-team
 spec:
@@ -111,7 +111,7 @@ Accept-Encoding: gzip
 HarborSync CRD configuration:
 
 ```yaml
-kind: HaborSync
+kind: HarborSync
 metadata:
   name: platform-team
 spec:


### PR DESCRIPTION
Changed `HaborSync` in usage docs to `HarborSync`

<!--

Thanks for sending a pull request!

Pre-flight checks:

Did you read the contributing and development guides?
 * https://github.com/moolen/harbor-sync/blob/master/CONTRIBUTING.md
 * http://moolen.github.io/harbor-sync/docs/development

Do the tests pass locally?
 * run: <make docker-test> to be sure that all tests pass

If this is a PR is a new feature please provide details and documentation about how to use it.

-->

**What this PR does**: Fixes small typo in docs

**Which issue this PR fixes**: None, small change

**Notes**:
