### PR TITLE
fix: robot account creation

### DIFF
--- a/pkg/harbor/robot.go
+++ b/pkg/harbor/robot.go
@@ -88,10 +88,6 @@ func (c *Client) CreateRobotAccount(name string, project Project) (*CreateRobotR
 				Resource: fmt.Sprintf("/project/%d/repository", project.ID),
 				Action:   "pull",
 			},
-			{
-				Resource: fmt.Sprintf("/project/%s/repository", project.Name),
-				Action:   "pull",
-			},
 		},
 	})
 


### PR DESCRIPTION
Looks like some recent Harbor version changed how the API works for the robot account creation and Harbor-Sync stopped working.

I tested the change in my own cluster and It seems to be working fine and the robot account creation works again.

Im using Harbor v1.10.0-6b84b62f