### PR TITLE
fix: start repo sync after being elected

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -151,6 +151,7 @@ var controllerCmd = &cobra.Command{
 		}
 		// +kubebuilder:scaffold:builder
 		log.Info("starting manager")
+		mgr.Add(harborRepo)
 		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 			log.Error(err, "problem running manager")
 			os.Exit(1)

--- a/pkg/harbor/repository/repository_test.go
+++ b/pkg/harbor/repository/repository_test.go
@@ -115,6 +115,8 @@ var _ = Describe("Repository", func() {
 		err = rep.Update()
 		Expect(err).ToNot(HaveOccurred())
 
+		stop := make(chan struct{})
+		go rep.Start(stop)
 		changeChan := rep.Sync()
 
 		// change the repo state
@@ -124,6 +126,7 @@ var _ = Describe("Repository", func() {
 		}()
 
 		<-changeChan
+		stop <- struct{}{}
 	})
 })
 


### PR DESCRIPTION
**What this PR does**:
Starts repository sync **after** being elected as leader.
If we start it too early, invalid metrics are being presented to prometheus which will not get updated until the app becomes leader.