### PR TITLE
fix: stop endless reconcile loop 94

### DIFF
--- a/pkg/controllers/util.go
+++ b/pkg/controllers/util.go
@@ -16,6 +16,8 @@ limitations under the License.
 package controllers
 
 import (
+	"time"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -25,15 +27,14 @@ import (
 
 // UpdateProjectStatusLastReconciliation sets the time when the robot was synced
 func UpdateProjectStatusLastReconciliation(status *crdv1.HarborSyncStatus, project harbor.Project) {
-	for i, p := range status.ProjectList {
+	for _, p := range status.ProjectList {
 		if p.Name == project.Name {
-			status.ProjectList[i].LastRobotReconciliation = metav1.Now()
 			return
 		}
 	}
 	status.ProjectList = append(status.ProjectList, crdv1.ProjectStatus{
 		Name:                    project.Name,
-		LastRobotReconciliation: metav1.Now(),
+		LastRobotReconciliation: metav1.NewTime(time.Date(1970, 1, 1, 12, 0, 0, 0, time.UTC)),
 		ManagedNamespaces:       []string{},
 	})
 }

--- a/pkg/reconciler/robot.go
+++ b/pkg/reconciler/robot.go
@@ -61,7 +61,7 @@ func ReconcileRobotAccounts(
 			"project_name":   project.Name,
 			"robot_account":  robot.Name,
 			"account_suffix": accountSuffix,
-		}).Info("trying to match robot account")
+		}).Debug("trying to match robot account")
 
 		// only one robot account will match
 		if matchRobotAccount(robot, project, accountSuffix) {


### PR DESCRIPTION
<!--

Thanks for sending a pull request!

Pre-flight checks:

Did you read the contributing and development guides?
 * https://github.com/moolen/harbor-sync/blob/master/CONTRIBUTING.md
 * http://moolen.github.io/harbor-sync/docs/development

Do the tests pass locally?
 * run: <make docker-test> to be sure that all tests pass

If this is a PR is a new feature please provide details and documentation about how to use it.

-->

**What this PR does**: This is a first draft of a fix for the endless reconcile loop.

The actual fix should put the compare functionality in a predicate for an event filter.

**Which issue this PR fixes**: fixes #94

**Notes**:

Still WIP but I needed HS to STFU.